### PR TITLE
feat: Modify CatDogDataset to Convert Images to RGB

### DIFF
--- a/user/image-classification/data.py
+++ b/user/image-classification/data.py
@@ -5,11 +5,12 @@ from PIL import Image
 from skimage import io
 from torch.utils.data import Dataset
 
+
 # ======================================================================================================================
 
 class CatDogDataset(Dataset):
     def __init__(self, files, transform=None):
-        self.files     = files
+        self.files = files
         self.transform = transform
 
     def __len__(self):
@@ -21,12 +22,13 @@ class CatDogDataset(Dataset):
 
         img_name = self.files[idx]
         image = io.imread(img_name)
-        image = Image.fromarray(image)
+        # Ensure the image is in RGB format
+        image = Image.fromarray(image).convert('RGB')
         if self.transform:
             image = self.transform(image)
         label = 0 if 'dog' in img_name else 1
         sample = (image, label)
-        #print(f'Fetched image: {idx} / {img_name}')
+        # print(f'Fetched image: {idx} / {img_name}')
         return sample
 
 # ======================================================================================================================


### PR DESCRIPTION
In the CatDogDataset class:
- Update the __getitem__ method to explicitly convert images to RGB format using the convert method.
- Ensure consistency in color channels during image preprocessing.

This enhancement addresses potential issues related to color format and improves the dataset preprocessing for downstream tasks